### PR TITLE
Update build.jl

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,2 +1,1 @@
-Pkg.clone("https://github.com/JuliaLinearAlgebra/AlgebraicMultigrid.jl", "AMG")
-Pkg.clone("https://github.com/ettersi/IncompleteSelectedInversion.jl")
+


### PR DESCRIPTION
This PR removes unnecessary legacy build instructions. This was pointed out in #3.