### PR TITLE
Fix incomplete cholesky

### DIFF
--- a/src/incompletecholesky.jl
+++ b/src/incompletecholesky.jl
@@ -25,18 +25,18 @@ end
 
 function CholeskyPreconditioner(A, memory=2)
     _A = get_data(A)
-    L, d, α = lldl(_A, memory=memory)
-    assert_pd(d, α)
-    update_L!(L, d)
-    return CholeskyPreconditioner(LowerTriangular(L), memory)
+    LLDL = lldl(_A, memory=memory)
+    assert_pd(LLDL.D, LLDL.α)
+    update_L!(LLDL.L, LLDL.D)
+    return CholeskyPreconditioner(LowerTriangular(LLDL.L), memory)
 end
 
 function UpdatePreconditioner!(C::CholeskyPreconditioner, A, memory=C.memory)
     _A = get_data(A)
-    L, d, α = lldl(_A, memory=memory)
-    assert_pd(d, α)
-    update_L!(L, d)
-    C.L = LowerTriangular(L)
+    LLDL = lldl(_A, memory=memory)
+    assert_pd(LLDL.D, LLDL.α)
+    update_L!(LLDL.L, LLDL.D)
+    C.L = LowerTriangular(LLDL.L)
     return C
 end
 


### PR DESCRIPTION
Running https://github.com/mohamed82008/Preconditioners.jl#examples failed with:

```julia
ERROR: MethodError: no method matching iterate(::LimitedLDLFactorizations.LimitedLDLFactorization{Float64, Int64})
Closest candidates are:
  iterate(::Union{LinRange, StepRangeLen}) at range.jl:664
  iterate(::Union{LinRange, StepRangeLen}, ::Int64) at range.jl:664
  iterate(::T) where T<:Union{Base.KeySet{var"#s79", var"#s78"} where {var"#s79", var"#s78"<:Dict}, Base.ValueIterator{var"#s77"} where var"#s77"<:Dict} at dict.jl:693
  ...
Stacktrace:
  [1] indexed_iterate(I::LimitedLDLFactorizations.LimitedLDLFactorization{Float64, Int64}, i::Int64)
    @ Base ./tuple.jl:89
  [2] CholeskyPreconditioner(A::SparseMatrixCSC{Float64, Int64}, memory::Int64)
    @ Preconditioners ~/.julia/packages/Preconditioners/03GuC/src/incompletecholesky.jl:28
```

Reference: https://github.com/JuliaSmoothOptimizers/LimitedLDLFactorizations.jl/pull/19