### PR TITLE
Fix allocations

### DIFF
--- a/src/diagonal.jl
+++ b/src/diagonal.jl
@@ -22,16 +22,19 @@ function UpdatePreconditioner!(D::DiagonalPreconditioner, K::AbstractMatrix)
 end
 @inline ldiv!(C::DiagonalPreconditioner, b) = ldiv!(b, C, b)
 @inline function ldiv!(y, C::DiagonalPreconditioner, b)
-    @inbounds @simd for i in 1:length(C.D)
-        y[i,:] .= view(b, i, :) ./ C.D[i]
+    @inbounds @simd for j ∈ 1:size(y, 2)
+        for i ∈ 1:length(C.D)
+            y[i,j] = b[i,j] / C.D[i]
+        end
     end
     return y
 end
 @inline function (\)(C::DiagonalPreconditioner, b)
     y = zero(b)
-    @inbounds @simd for i in 1:length(C.D)
-        y[i,:] .= view(b, i, :) / C.D[i]
+    @inbounds @simd for j ∈ 1:size(y, 2)
+        for i ∈ 1:length(C.D)
+            y[i,j] = b[i,j] / C.D[i]
+        end
     end
     return y
 end
-


### PR DESCRIPTION
While I'm on this, fix https://github.com/mohamed82008/Preconditioners.jl/issues/12.

```julia
import IterativeSolvers
import Preconditioners
import BenchmarkTools
import IncompleteLU
import MatrixDepot

main() = begin
  # Create a Wathen matrix
  NX, NY = 100, 100
  A = MatrixDepot.wathen(NX, NY)
  b = rand(size(A, 1))

  # Precompute Preconditioners
  PL_ilu = IncompleteLU.ilu(A, τ=1e-2)
  PL_jac = Preconditioners.DiagonalPreconditioner(A)
  PL_amg_1 = Preconditioners.AMGPreconditioner{Preconditioners.RugeStuben}(A)
  PL_amg_2 = Preconditioners.AMGPreconditioner{Preconditioners.SmoothedAggregation}(A)

  # Benchmark the solvers
  println("Direct Solver (\\)")
  BenchmarkTools.@btime $A \ $b

  println("Iterative Solver (cg)")
  BenchmarkTools.@btime IterativeSolvers.cg($A, $b, reltol=1e-5)

  println("Iterative Solver (pcg-ilu)")
  BenchmarkTools.@btime IterativeSolvers.cg($A, $b, reltol=1e-5, Pl=$PL_ilu)

  println("Iterative Solver (pcg-jac)")
  BenchmarkTools.@btime IterativeSolvers.cg($A, $b, reltol=1e-5, Pl=$PL_jac)

  println("Iterative Solver (pcg-amg:rs)")
  BenchmarkTools.@btime IterativeSolvers.cg($A, $b, reltol=1e-5, Pl=$PL_amg_1)

  println("Iterative Solver (pcg-amg:sa)")
  BenchmarkTools.@btime IterativeSolvers.cg($A, $b, reltol=1e-5, Pl=$PL_amg_2)
  return
end

main()
```

Output
---
```julia
Direct Solver (\)
  109.960 ms (52 allocations: 51.89 MiB)
Iterative Solver (cg)
  224.699 ms (16 allocations: 951.36 KiB)
Iterative Solver (pcg-ilu)
  11.859 ms (16 allocations: 951.44 KiB)
Iterative Solver (pcg-jac)
  64.358 ms (16 allocations: 951.36 KiB)  # <===== All good
Iterative Solver (pcg-amg:rs)
  70.661 ms (16 allocations: 951.36 KiB)
Iterative Solver (pcg-amg:sa)
  57.407 ms (16 allocations: 951.36 KiB)
```