### PR TITLE
remove unused type variable

### DIFF
--- a/src/incompletecholesky.jl
+++ b/src/incompletecholesky.jl
@@ -21,7 +21,7 @@ function UpdatePreconditioner!(C::CholeskyPreconditioner, A, memory=C.memory)
     return C
 end
 
-@inline function ldiv!(C::CholeskyPreconditioner, y::AbstractVector) where {T}
+@inline function ldiv!(C::CholeskyPreconditioner, y::AbstractVector)
     ldiv!(y, C.ldlt, copy(y))
     return y
 end


### PR DESCRIPTION
This shows up in precompilation warnings:
```julia
┌ Preconditioners [af69fa37-3177-5a40-98ee-561f696e4fcd]
│  WARNING: method definition for ldiv! at [...]/.julia/packages/Preconditioners/3UYhL/src/incompletecholesky.jl:24 declares type variable T but does not use it.
└
```